### PR TITLE
Verbose mode: Print full final server response

### DIFF
--- a/rsa_ct_kip/client.py
+++ b/rsa_ct_kip/client.py
@@ -139,6 +139,8 @@ def main(args=None):
     req2 = soap.make_ClientRequest('ServerFinished', pd, req2_filled)
     print("Sending ServerFinished request to server, with encrypted client nonce...")
     raw_res2 = s.send(s.prepare_request(req2))
+    if args.verbose:
+        print(raw_res2.text)
     pd_res2, res2 = soap.parse_ServerResponse(raw_res2)
     if args.verbose:
         print(res2)

--- a/rsa_ct_kip/client.py
+++ b/rsa_ct_kip/client.py
@@ -112,7 +112,7 @@ def main(args=None):
         print(raw_res1.text)
     pd_res1, res1 = soap.parse_ServerResponse(raw_res1)
     if args.verbose:
-        print(res1)
+        print(ET.tostring(res1))
 
     session_id = res1.attrib['SessionID']
     k = res1.find('EncryptionKey/dsig:KeyValue/dsig:RSAKeyValue', ns)
@@ -143,7 +143,7 @@ def main(args=None):
         print(raw_res2.text)
     pd_res2, res2 = soap.parse_ServerResponse(raw_res2)
     if args.verbose:
-        print(res2)
+        print(ET.tostring(res2))
 
     # get stuff from response
     service_id = get_text(res2.find('ServiceID'))


### PR DESCRIPTION
It is needed to examine XML contents; the processed response just prints an
opaque Python object pointer, which isn't useful after the process has
exited.